### PR TITLE
Added Loot and Consumable tables in new Tables compendium

### DIFF
--- a/data/srd-items/Control_Relic_MZmHHEXMCSQBncUR.yml
+++ b/data/srd-items/Control_Relic_MZmHHEXMCSQBncUR.yml
@@ -1,0 +1,32 @@
+name: Control Relic
+type: item
+folder: YayQIYitpacIM2u2
+_id: MZmHHEXMCSQBncUR
+img: icons/commodities/treasure/token-worn-yang-brown.webp
+system:
+  description: <p>You gain a +1 bonus to your Finesse. You can only carry one relic.</p>
+  category: Item
+  rarity: Reusable
+  location: abilities
+  quantity: 1
+  weight: 0
+  attributes: {}
+  groups: {}
+  resourceTrackers: []
+effects: []
+sort: 0
+ownership:
+  default: 0
+  PBdPE9squMuZKhHK: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.346'
+  systemId: daggerheart
+  systemVersion: 2.11.5
+  createdTime: 1754157923095
+  modifiedTime: 1754157976903
+  lastModifiedBy: PBdPE9squMuZKhHK
+_key: '!items!MZmHHEXMCSQBncUR'

--- a/data/srd-items/Gill_Salve_sdQSxxWD1GFzCuBv.yml
+++ b/data/srd-items/Gill_Salve_sdQSxxWD1GFzCuBv.yml
@@ -2,7 +2,7 @@ name: Gill Salve
 type: item
 folder: mBkEaHY2IDFQbm6q
 _id: sdQSxxWD1GFzCuBv
-img: icons/containers/kitchenware/vase-clay-etched-brown.webp
+img: icons/containers/kitchenware/vase-clay-painted-blue-gold.webp
 system:
   description: >-
     <p>You can apply this salve to your neck to breathe underwater for a number
@@ -30,6 +30,6 @@ _stats:
   systemId: daggerheart
   systemVersion: 2.11.5
   createdTime: 1754138330052
-  modifiedTime: 1754138330052
+  modifiedTime: 1754158546872
   lastModifiedBy: PBdPE9squMuZKhHK
 _key: '!items!sdQSxxWD1GFzCuBv'

--- a/data/srd-materials/Vicious_Entangle_l91N3i1R6tGTenWx.yml
+++ b/data/srd-materials/Vicious_Entangle_l91N3i1R6tGTenWx.yml
@@ -10,7 +10,7 @@ system:
     ground, dealing [[/roll 1d8+1]] physical damage and temporarily
     @UUID[Compendium.daggerheart-srd.srd-materials.Item.967FSSCW150Zpp5E]{restraining}the
     target.</p><p>Additionally on a success, you can spend a Hope to temporarily
-    @UUID[Compendium.mikes-daggerheart-compendiums.mike-dh-references.Item.oYhv37yGK1xLTS6y]{Restrain}
+    @UUID[Compendium.daggerheart-srd.srd-materials.Item.967FSSCW150Zpp5E]{restrain}
     another adversary within <strong>Very Close</strong> range of your
     target.</p>
   category: Sage - level 1
@@ -31,7 +31,7 @@ _stats:
   systemId: daggerheart
   systemVersion: 2.11.5
   createdTime: 1754139708798
-  modifiedTime: 1754144129671
+  modifiedTime: 1754152577894
   lastModifiedBy: PBdPE9squMuZKhHK
 sort: 0
 ownership:

--- a/data/srd-tables/Consumables_FQafxTWOHgUeycVu.yml
+++ b/data/srd-tables/Consumables_FQafxTWOHgUeycVu.yml
@@ -1388,7 +1388,7 @@ results:
       lastModifiedBy: PBdPE9squMuZKhHK
     _key: '!tables.results!FQafxTWOHgUeycVu.QzIGE4cVpRtkosmG'
 replacement: true
-displayRoll: true
+displayRoll: false
 folder: null
 sort: 0
 ownership:
@@ -1403,7 +1403,7 @@ _stats:
   systemId: daggerheart
   systemVersion: 2.11.5
   createdTime: 1754156973720
-  modifiedTime: 1754158825325
+  modifiedTime: 1754159761390
   lastModifiedBy: PBdPE9squMuZKhHK
 formula: 1d60
 _key: '!tables!FQafxTWOHgUeycVu'

--- a/data/srd-tables/Consumables_FQafxTWOHgUeycVu.yml
+++ b/data/srd-tables/Consumables_FQafxTWOHgUeycVu.yml
@@ -1,0 +1,1409 @@
+name: Consumables
+_id: FQafxTWOHgUeycVu
+img: icons/consumables/potions/potion-bottle-corked-labeled-red.webp
+description: ''
+results:
+  - type: document
+    weight: 1
+    range:
+      - 1
+      - 1
+    _id: UXmkfWreDAQoMZ1j
+    name: Stride Potion
+    img: icons/consumables/potions/bottle-bulb-corked-green.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158030259
+      modifiedTime: 1754158086696
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.DrAbe3vSR7ukUjmR
+    _key: '!tables.results!FQafxTWOHgUeycVu.UXmkfWreDAQoMZ1j'
+  - type: document
+    weight: 1
+    range:
+      - 2
+      - 2
+    _id: AknrHYKGpsHeZKaD
+    name: Bolster Potion
+    img: icons/consumables/potions/potion-vial-tube-yellow.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158049598
+      modifiedTime: 1754158108123
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.aFMTz3f6EmWH2CGx
+    _key: '!tables.results!FQafxTWOHgUeycVu.AknrHYKGpsHeZKaD'
+  - type: document
+    weight: 1
+    range:
+      - 3
+      - 3
+    _id: M1pckr67HBLogzAF
+    name: Control Potion
+    img: icons/consumables/potions/potion-tube-corked-labeled-cyan.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158050114
+      modifiedTime: 1754158117432
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.NJxz3hOHiKSlJojY
+    _key: '!tables.results!FQafxTWOHgUeycVu.M1pckr67HBLogzAF'
+  - type: document
+    weight: 1
+    range:
+      - 4
+      - 4
+    _id: zdCyJq4UL8Ie5fWw
+    name: Attune Potion
+    img: icons/consumables/potions/potion-tube-corked-blue.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158050300
+      modifiedTime: 1754158130906
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.BLu00fffAcfs3YMk
+    _key: '!tables.results!FQafxTWOHgUeycVu.zdCyJq4UL8Ie5fWw'
+  - type: document
+    weight: 1
+    range:
+      - 5
+      - 5
+    _id: afON8LEVZDn0eFUj
+    name: Charm Potion
+    img: icons/consumables/potions/potion-flask-corked-labeled-pink.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158050481
+      modifiedTime: 1754158139648
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.echxUTkYcSwzPYcN
+    _key: '!tables.results!FQafxTWOHgUeycVu.afON8LEVZDn0eFUj'
+  - type: document
+    weight: 1
+    range:
+      - 6
+      - 6
+    name: Enlighten Potion
+    img: icons/consumables/potions/vial-cork-blue.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.fQYxQYDvDMVuUpuf
+    _id: SnvIiy7yPOfZLfF4
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158388991
+      modifiedTime: 1754158388991
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.SnvIiy7yPOfZLfF4'
+  - type: document
+    weight: 1
+    range:
+      - 7
+      - 7
+    name: Minor Health Potion
+    img: icons/consumables/potions/potion-tube-corked-red.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.02UTsK4t9cTWJv96
+    _id: Ps1YaQskVfS18oWf
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158437886
+      modifiedTime: 1754158437886
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.Ps1YaQskVfS18oWf'
+  - type: document
+    weight: 1
+    range:
+      - 8
+      - 8
+    name: Minor Stamina Potion
+    img: icons/consumables/potions/potion-tube-corked-green.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.kuQEDwquGtNCKHN3
+    _id: ey6WUhz7grzKY1j1
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158442449
+      modifiedTime: 1754158442449
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.ey6WUhz7grzKY1j1'
+  - type: document
+    weight: 1
+    range:
+      - 9
+      - 9
+    name: Grindletooth Venom
+    img: >-
+      icons/consumables/potions/bottle-conical-corked-labeled-skull-poison-green.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.ZovcvYLRMbwf755c
+    _id: KKgV5uIy9NAhlUoO
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158448840
+      modifiedTime: 1754158448840
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.KKgV5uIy9NAhlUoO'
+  - type: document
+    weight: 1
+    range:
+      - 10
+      - 10
+    name: Varik Leaves
+    img: icons/consumables/plants/leaf-eaten-holes-green.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.NVrHzR8Gw8SPVmeN
+    _id: BHJC8spn364I2USD
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158452340
+      modifiedTime: 1754158452340
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.BHJC8spn364I2USD'
+  - type: document
+    weight: 1
+    range:
+      - 11
+      - 11
+    name: Vial of Moondrip
+    img: icons/magic/perception/eye-ringed-glow-angry-small-teal.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.ovzjGp0UUVSic8Lc
+    _id: bjtoyW3EWWVtbqWo
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158457838
+      modifiedTime: 1754158457838
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.bjtoyW3EWWVtbqWo'
+  - type: document
+    weight: 1
+    range:
+      - 12
+      - 12
+    name: Unstable Arcane Shard
+    img: icons/commodities/gems/gem-shattered-teal.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.MxZS6OK19lkA7t3j
+    _id: TAbFD2yDbb689EHQ
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158462484
+      modifiedTime: 1754158462484
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.TAbFD2yDbb689EHQ'
+  - type: document
+    weight: 1
+    range:
+      - 13
+      - 13
+    name: Potion of Stability
+    img: icons/consumables/potions/potion-bottle-corked-labeled-green.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.avvg5G32kvDaSujy
+    _id: I9LKiuMg6nkqfgxM
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158467167
+      modifiedTime: 1754158467167
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.I9LKiuMg6nkqfgxM'
+  - type: document
+    weight: 1
+    range:
+      - 14
+      - 14
+    name: Improved Grindletooth Venom
+    img: >-
+      icons/consumables/potions/bottle-conical-corked-labeled-skull-poison-green.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.WpPcnzxQlFcOy9zq
+    _id: Py6q7tadbIcUAyTL
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158471298
+      modifiedTime: 1754158471298
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.Py6q7tadbIcUAyTL'
+  - type: document
+    weight: 1
+    range:
+      - 15
+      - 15
+    name: Morphing Clay
+    img: icons/containers/kitchenware/vase-clay-etched-brown.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.iNKeUIo4QnRR58BT
+    _id: M562KMCotNzfvtMg
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158478534
+      modifiedTime: 1754158478534
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.M562KMCotNzfvtMg'
+  - type: document
+    weight: 1
+    range:
+      - 16
+      - 16
+    name: Vial of Darksmoke
+    img: icons/commodities/tech/smoke-bomb-purple.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.q8Gk7KyaXcZiLn0Y
+    _id: 9a0utEMvuFXLyjjD
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158484723
+      modifiedTime: 1754158484723
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.9a0utEMvuFXLyjjD'
+  - type: document
+    weight: 1
+    range:
+      - 17
+      - 17
+    name: Jumping Root
+    img: icons/consumables/plants/dried-stem-vine-root-bramble-brown.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.1M48KvgW6T26ynTy
+    _id: CnHvBJGBoRlisAMR
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158492933
+      modifiedTime: 1754158492933
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.CnHvBJGBoRlisAMR'
+  - type: document
+    weight: 1
+    range:
+      - 18
+      - 18
+    name: Snap Powder
+    img: icons/commodities/materials/powder-teal.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.SlRQPHk7Y1X04eRW
+    _id: Z56fn1UXr04d4p2y
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158497387
+      modifiedTime: 1754158497387
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.Z56fn1UXr04d4p2y'
+  - type: document
+    weight: 1
+    range:
+      - 19
+      - 19
+    name: Health Potion
+    img: icons/consumables/potions/bottle-corked-red.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.SD99FVJVeVET0UdN
+    _id: EDHXj2ofFFiy3mja
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158504304
+      modifiedTime: 1754158504304
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.EDHXj2ofFFiy3mja'
+  - type: document
+    weight: 1
+    range:
+      - 20
+      - 20
+    name: Stamina Potion
+    img: icons/consumables/potions/bottle-corked-green.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.36uTNkpKEDNRBI14
+    _id: Pha3HUL79Z5rALva
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158509740
+      modifiedTime: 1754158509740
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.Pha3HUL79Z5rALva'
+  - type: document
+    weight: 1
+    range:
+      - 21
+      - 21
+    name: Armor Stitcher
+    img: icons/tools/hand/needle-grey.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.OJoy82cvaGDIvq85
+    _id: iXCZo5NZxiU4Gx5t
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158516682
+      modifiedTime: 1754158516682
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.iXCZo5NZxiU4Gx5t'
+  - type: document
+    weight: 1
+    range:
+      - 22
+      - 22
+    name: Gill Salve
+    img: icons/containers/kitchenware/vase-clay-painted-blue-gold.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.sdQSxxWD1GFzCuBv
+    _id: DOjYUcOBkKcSnWuV
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158552679
+      modifiedTime: 1754158552679
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.DOjYUcOBkKcSnWuV'
+  - type: document
+    weight: 1
+    range:
+      - 23
+      - 23
+    name: Replication Parchment
+    img: icons/sundries/documents/blueprint-recipe-alchemical.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.H9VsPXsVItXirDjR
+    _id: xqDmojIW1cusIhue
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158558895
+      modifiedTime: 1754158558895
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.xqDmojIW1cusIhue'
+  - type: document
+    weight: 1
+    range:
+      - 24
+      - 24
+    name: Improved Arcane Shard
+    img: icons/commodities/gems/gem-faceted-trillion-blue.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.75YEWNNJwBeSZ2Cz
+    _id: d5fErePXtVdZ15ZX
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158565955
+      modifiedTime: 1754158565955
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.d5fErePXtVdZ15ZX'
+  - type: document
+    weight: 1
+    range:
+      - 25
+      - 25
+    name: Major Stride Potion
+    img: icons/consumables/potions/bottle-round-label-cork-green.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.BAeoJazgCZHQXY4Q
+    _id: QmfZ6kliThWp66Fg
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158577687
+      modifiedTime: 1754158577687
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.QmfZ6kliThWp66Fg'
+  - type: document
+    weight: 1
+    range:
+      - 26
+      - 26
+    name: Major Bolster Potion
+    img: icons/consumables/potions/bottle-round-label-cork-yellow.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.NwFaUf9mM7qZFdtY
+    _id: 8FuWv7fBFVQN5TKc
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158578986
+      modifiedTime: 1754158578986
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.8FuWv7fBFVQN5TKc'
+  - type: document
+    weight: 1
+    range:
+      - 27
+      - 27
+    name: Major Control Potion
+    img: icons/consumables/potions/bottle-round-label-cork-red.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.kZFgqrYaRtH7uK4f
+    _id: sgXzs0mV5o1O8hvv
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158580304
+      modifiedTime: 1754158580304
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.sgXzs0mV5o1O8hvv'
+  - type: document
+    weight: 1
+    range:
+      - 28
+      - 28
+    name: Major Attune Potion
+    img: icons/consumables/potions/potion-jar-corked-glowing-blue.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.iWNtV35l0ZqD85cC
+    _id: 7PZv1Ro0tRhlyT5c
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158590139
+      modifiedTime: 1754158590139
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.7PZv1Ro0tRhlyT5c'
+  - type: document
+    weight: 1
+    range:
+      - 29
+      - 29
+    name: Major Charm Potion
+    img: icons/consumables/potions/bottle-round-label-cork-purple.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.zsMWS4FRpBzqz5wL
+    _id: mIi4ifyHKFAMVVnT
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158592792
+      modifiedTime: 1754158592792
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.mIi4ifyHKFAMVVnT'
+  - type: document
+    weight: 1
+    range:
+      - 30
+      - 30
+    name: Major Enlighten Potion
+    img: icons/consumables/potions/bottle-round-label-cork-blue.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.a66MoWqPnekZmn5N
+    _id: Ra9lziSNRiC1yJqG
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158593862
+      modifiedTime: 1754158593862
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.Ra9lziSNRiC1yJqG'
+  - type: document
+    weight: 1
+    range:
+      - 31
+      - 31
+    name: Blood of the Yorgi
+    img: >-
+      icons/consumables/potions/potion-bottle-labeled-medicine-capped-red-black.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.IXrpUlRAvBV0uIun
+    _id: ERBo00NmYyInCYXD
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158602169
+      modifiedTime: 1754158602169
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.ERBo00NmYyInCYXD'
+  - type: document
+    weight: 1
+    range:
+      - 32
+      - 32
+    name: Homet’s Secret Potion
+    img: icons/consumables/potions/bottle-bulb-corked-labeled-blue.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.6WnSCvewoVtiXQx5
+    _id: TELoQn944HiPVEVK
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158607686
+      modifiedTime: 1754158607686
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.TELoQn944HiPVEVK'
+  - type: document
+    weight: 1
+    range:
+      - 33
+      - 33
+    name: Redthorn Saliva
+    img: icons/consumables/potions/round-cork-leaf-green.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.Fk6pWBEQbJcP1H2T
+    _id: qTEgHrwO4cu2OoFj
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158618584
+      modifiedTime: 1754158618584
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.qTEgHrwO4cu2OoFj'
+  - type: document
+    weight: 1
+    range:
+      - 34
+      - 34
+    name: Channelstone
+    img: icons/commodities/stone/engraved-symbol-water-grey.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.bWny7nMeQ1R1rZdc
+    _id: rNkI8YsnEW6gy3Dl
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158625276
+      modifiedTime: 1754158625276
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.rNkI8YsnEW6gy3Dl'
+  - type: document
+    weight: 1
+    range:
+      - 35
+      - 35
+    name: Mythic Dust
+    img: icons/tools/laboratory/bowl-powder-purple.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.GcwRcLk4W2y3ZWG1
+    _id: JyBTDItZOFeEVf5L
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158631995
+      modifiedTime: 1754158631995
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.JyBTDItZOFeEVf5L'
+  - type: document
+    weight: 1
+    range:
+      - 36
+      - 36
+    name: Acidpaste
+    img: icons/magic/acid/dissolve-pool-bubbles.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.Zeoo3ivtDERfuzBn
+    _id: tfwI20OdGwClzCKV
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158636717
+      modifiedTime: 1754158636717
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.tfwI20OdGwClzCKV'
+  - type: document
+    weight: 1
+    range:
+      - 37
+      - 37
+    name: Hopehold Flare
+    img: icons/magic/light/projectile-flare-blue.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.9KJatcDmnZb8KUr0
+    _id: 9dfgMQAXZUgZUQnC
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158641427
+      modifiedTime: 1754158641427
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.9dfgMQAXZUgZUQnC'
+  - type: document
+    weight: 1
+    range:
+      - 38
+      - 38
+    name: Major Arcane Shard
+    img: icons/commodities/gems/gem-faceted-teardrop-blue.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.7rgE3g9kwLZEhF5h
+    _id: eAKw4h7Y168yGe90
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158646707
+      modifiedTime: 1754158646707
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.eAKw4h7Y168yGe90'
+  - type: document
+    weight: 1
+    range:
+      - 39
+      - 39
+    name: Featherbone
+    img: icons/commodities/materials/feather-curled-white.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.KoaPBzuSxd9teoIn
+    _id: GQTrBYaNydTfMWPS
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158652270
+      modifiedTime: 1754158652270
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.GQTrBYaNydTfMWPS'
+  - type: document
+    weight: 1
+    range:
+      - 40
+      - 40
+    name: Circle of the Void
+    img: icons/creatures/eyes/void-single-black-purple.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.HjnBsQD3vWpBR6br
+    _id: iCyJgiaxheFhL5S5
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158660692
+      modifiedTime: 1754158660692
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.iCyJgiaxheFhL5S5'
+  - type: document
+    weight: 1
+    range:
+      - 41
+      - 41
+    name: Sun Tree Sap
+    img: icons/environment/wilderness/tree-oak.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.UanwmU0xsBq2t6ac
+    _id: E8DFBW9Pm4sTXOib
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158667888
+      modifiedTime: 1754158667888
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.E8DFBW9Pm4sTXOib'
+  - type: document
+    weight: 1
+    range:
+      - 42
+      - 42
+    name: Dripfang Poison
+    img: >-
+      icons/consumables/potions/potion-jar-corked-labeled-poison-skull-green.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.CNApnUV7JyAa4nYG
+    _id: A1t5BXN1hvDVNJiv
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158676816
+      modifiedTime: 1754158676816
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.A1t5BXN1hvDVNJiv'
+  - type: document
+    weight: 1
+    range:
+      - 43
+      - 43
+    name: Major Health Potion
+    img: icons/consumables/potions/bottle-round-corked-orante-red.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.5qzx5a0TXWpqLvxl
+    _id: MV2QRDWxegKtKTtB
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158683438
+      modifiedTime: 1754158683438
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.MV2QRDWxegKtKTtB'
+  - type: document
+    weight: 1
+    range:
+      - 44
+      - 44
+    name: Major Stamina Potion
+    img: icons/consumables/potions/bottle-bulb-corked-green.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.FFuctSKnwUBftNLR
+    _id: cwzx6BcqOAHRZ1Fx
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158691921
+      modifiedTime: 1754158691921
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.cwzx6BcqOAHRZ1Fx'
+  - type: document
+    weight: 1
+    range:
+      - 45
+      - 45
+    name: Ogre Musk
+    img: icons/magic/acid/dissolve-vomit-green-brown.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.YzByTWLgWISFojex
+    _id: kxBtgD5KoASZj3uj
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158706043
+      modifiedTime: 1754158706043
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.kxBtgD5KoASZj3uj'
+  - type: document
+    weight: 1
+    range:
+      - 46
+      - 46
+    name: Wingsprout
+    img: icons/commodities/materials/feather-white-glowing-beams.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.DpE1VvjWTkSemz9T
+    _id: obbw2N6TVrRD4fXZ
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158744243
+      modifiedTime: 1754158744243
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.obbw2N6TVrRD4fXZ'
+  - type: document
+    weight: 1
+    range:
+      - 47
+      - 47
+    name: Jar of Lost Voices
+    img: icons/consumables/drinks/clay-jar-glowing-orange-blue.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.7JCqrurmsPM0FyAG
+    _id: P3x79jVNhIpHSfON
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158750281
+      modifiedTime: 1754158750281
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.P3x79jVNhIpHSfON'
+  - type: document
+    weight: 1
+    range:
+      - 48
+      - 48
+    name: Dragonbloom Tea
+    img: icons/consumables/fruit/dragonfruit-red-green.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.4k8aywdUwW9QL3kY
+    _id: gHhSRN1gB2iAGvtS
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158756788
+      modifiedTime: 1754158756788
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.gHhSRN1gB2iAGvtS'
+  - type: document
+    weight: 1
+    range:
+      - 49
+      - 49
+    name: Bridge Seed
+    img: icons/commodities/materials/plant-sprout-seed-brown-green.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.WXEdhXcPqJBU33DH
+    _id: rUjm90K8j2aqWFcH
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158762105
+      modifiedTime: 1754158762105
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.rUjm90K8j2aqWFcH'
+  - type: document
+    weight: 1
+    range:
+      - 50
+      - 50
+    name: Sleeping Sap
+    img: icons/consumables/potions/bottle-conical-corked-cyan.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.8oAUJsThjpuTxM7D
+    _id: TeDQ9j8vhJYgaQlU
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158768982
+      modifiedTime: 1754158768982
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.TeDQ9j8vhJYgaQlU'
+  - type: document
+    weight: 1
+    range:
+      - 51
+      - 51
+    name: Feast of Xuria
+    img: icons/consumables/food/berries-cream-bowl-mint-red.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.tp9mQVyi2I6WbrCW
+    _id: 18RQYEnGIf3sxvE3
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158773732
+      modifiedTime: 1754158773732
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.18RQYEnGIf3sxvE3'
+  - type: document
+    weight: 1
+    range:
+      - 52
+      - 52
+    name: Bonding Honey
+    img: icons/consumables/food/honey-beehive-brown.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.KTVhooKa8RHfYiDI
+    _id: hjRmT1vVzUUW5j2r
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158779261
+      modifiedTime: 1754158779261
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.hjRmT1vVzUUW5j2r'
+  - type: document
+    weight: 1
+    range:
+      - 53
+      - 53
+    name: Shrinking Potion
+    img: icons/consumables/potions/potion-vial-corked-labeled-purple.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.WEFaQD3ejZ6OHHUI
+    _id: rYywL0dLNkdHyqBU
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158786885
+      modifiedTime: 1754158786885
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.rYywL0dLNkdHyqBU'
+  - type: document
+    weight: 1
+    range:
+      - 54
+      - 54
+    name: Growing Potion
+    img: icons/consumables/potions/potion-flask-corked-shiny-red.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.0c9seymuZqWrx2dh
+    _id: w57MQjo0D623bOR2
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158791947
+      modifiedTime: 1754158791947
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.w57MQjo0D623bOR2'
+  - type: document
+    weight: 1
+    range:
+      - 55
+      - 55
+    name: Knowledge Stone
+    img: icons/commodities/treasure/token-engraved-blue-glowing.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.tZcQjxkNGf8ApjJJ
+    _id: yiJUhhBEEtz0fL0e
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158797787
+      modifiedTime: 1754158797787
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.yiJUhhBEEtz0fL0e'
+  - type: document
+    weight: 1
+    range:
+      - 56
+      - 56
+    name: Sweet Moss
+    img: icons/tools/laboratory/bowl-herbs-green.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.AsLPnbn8ftlkhmLB
+    _id: QAfNdPIxzrscEzaG
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158803126
+      modifiedTime: 1754158803126
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.QAfNdPIxzrscEzaG'
+  - type: document
+    weight: 1
+    range:
+      - 57
+      - 57
+    name: Blinding Orb
+    img: icons/commodities/gems/pearl-blue-gold.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.2dbXKnuwSOkOYX7Y
+    _id: O2VEyJ66WeksQYUL
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158807821
+      modifiedTime: 1754158807821
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.O2VEyJ66WeksQYUL'
+  - type: document
+    weight: 1
+    range:
+      - 58
+      - 58
+    name: Death Tea
+    img: icons/consumables/potions/potion-bottle-skull-label-poison-teal.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.sfNFKndBiARK9Uwu
+    _id: K3lVVgFRwzYWFO07
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158812578
+      modifiedTime: 1754158812578
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.K3lVVgFRwzYWFO07'
+  - type: document
+    weight: 1
+    range:
+      - 59
+      - 59
+    name: Mirror of Marigold
+    img: icons/sundries/survival/mirror-plain.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.qELaNXSwf3oX6L4y
+    _id: 1BcK6y5bUKuRohhI
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158817684
+      modifiedTime: 1754158817684
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.1BcK6y5bUKuRohhI'
+  - type: document
+    weight: 1
+    range:
+      - 60
+      - 60
+    name: Stardrop
+    img: icons/magic/light/explosion-star-glow-blue.webp
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.DPjLN4b02HyNFizD
+    _id: QzIGE4cVpRtkosmG
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754158821277
+      modifiedTime: 1754158821277
+      lastModifiedBy: PBdPE9squMuZKhHK
+    _key: '!tables.results!FQafxTWOHgUeycVu.QzIGE4cVpRtkosmG'
+replacement: true
+displayRoll: true
+folder: null
+sort: 0
+ownership:
+  default: 0
+  PBdPE9squMuZKhHK: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.346'
+  systemId: daggerheart
+  systemVersion: 2.11.5
+  createdTime: 1754156973720
+  modifiedTime: 1754158825325
+  lastModifiedBy: PBdPE9squMuZKhHK
+formula: 1d60
+_key: '!tables!FQafxTWOHgUeycVu'

--- a/data/srd-tables/Loot_YJQvjVgQD0LgytY3.yml
+++ b/data/srd-tables/Loot_YJQvjVgQD0LgytY3.yml
@@ -1,0 +1,1405 @@
+name: Loot
+_id: YJQvjVgQD0LgytY3
+img: icons/commodities/treasure/token-runed-fehu-gold.webp
+description: ''
+results:
+  - type: document
+    weight: 1
+    range:
+      - 1
+      - 1
+    _id: pNR31hnAd8KtOocN
+    name: Premium Bedroll
+    img: icons/sundries/survival/bedroll-blue-red.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157055575
+      modifiedTime: 1754157130894
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.Fat9RaU1Ru4iflZQ
+    _key: '!tables.results!YJQvjVgQD0LgytY3.pNR31hnAd8KtOocN'
+  - type: document
+    weight: 1
+    range:
+      - 2
+      - 2
+    _id: oLCGmFJfbItFk0iq
+    name: Piper Whistle
+    img: icons/tools/instruments/pipe-flue-tan.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157055751
+      modifiedTime: 1754157153231
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.qvR0mKBIlS7vO9cy
+    _key: '!tables.results!YJQvjVgQD0LgytY3.oLCGmFJfbItFk0iq'
+  - type: document
+    weight: 1
+    range:
+      - 3
+      - 3
+    _id: gxqw1tailrhm5H3A
+    name: Charging Quiver
+    img: icons/containers/ammunition/arrows-quiver-black.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157055922
+      modifiedTime: 1754157180393
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.0jeXnlUfAyo8K1tK
+    _key: '!tables.results!YJQvjVgQD0LgytY3.gxqw1tailrhm5H3A'
+  - type: document
+    weight: 1
+    range:
+      - 4
+      - 4
+    _id: icYg6r3Da3jsy88L
+    name: Alistair's Torch
+    img: icons/sundries/lights/torch-brown-lit.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157056091
+      modifiedTime: 1754157194182
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.tbRbKn6XUg26veGv
+    _key: '!tables.results!YJQvjVgQD0LgytY3.icYg6r3Da3jsy88L'
+  - type: document
+    weight: 1
+    range:
+      - 5
+      - 5
+    _id: Wpc3wD4E7gMxlc1j
+    name: Speaking Orbs
+    img: icons/commodities/treasure/brooch-pink-orbs.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157056270
+      modifiedTime: 1754157213414
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.Aye1nuPPvP2ryvcB
+    _key: '!tables.results!YJQvjVgQD0LgytY3.Wpc3wD4E7gMxlc1j'
+  - type: document
+    weight: 1
+    range:
+      - 6
+      - 6
+    _id: LEPhzG5jGHs3WpvE
+    name: Manacles
+    img: icons/sundries/survival/cuffs-shackles-steel.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157056450
+      modifiedTime: 1754157236672
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.TSURw1Pky1USVsKt
+    _key: '!tables.results!YJQvjVgQD0LgytY3.LEPhzG5jGHs3WpvE'
+  - type: document
+    weight: 1
+    range:
+      - 7
+      - 7
+    _id: 4WtznRCKO5XzpYrg
+    name: Arcane Cloak
+    img: icons/equipment/back/cloak-collared-feathers-green.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157056633
+      modifiedTime: 1754157248007
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.Om51b249yPsP520e
+    _key: '!tables.results!YJQvjVgQD0LgytY3.4WtznRCKO5XzpYrg'
+  - type: document
+    weight: 1
+    range:
+      - 8
+      - 8
+    _id: vscXdppjJCdYfB6T
+    name: Woven Net
+    img: icons/tools/fishing/net-tan.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157056810
+      modifiedTime: 1754157284491
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.zUwDLRIOw6jzx3px
+    _key: '!tables.results!YJQvjVgQD0LgytY3.vscXdppjJCdYfB6T'
+  - type: document
+    weight: 1
+    range:
+      - 9
+      - 9
+    _id: NFLyh59KdDPrhAAm
+    name: Fire Jar
+    img: icons/consumables/potions/potion-jar-corked-orange.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157056988
+      modifiedTime: 1754157298124
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.SA64frYGofqESSrV
+    _key: '!tables.results!YJQvjVgQD0LgytY3.NFLyh59KdDPrhAAm'
+  - type: document
+    weight: 1
+    range:
+      - 10
+      - 10
+    _id: jJ4OA6PbWXTPyUw6
+    name: Suspended Rod
+    img: icons/commodities/tech/pipe-lead-closed.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157057171
+      modifiedTime: 1754157320066
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.cFIVGQJDomXH0GFS
+    _key: '!tables.results!YJQvjVgQD0LgytY3.jJ4OA6PbWXTPyUw6'
+  - type: document
+    weight: 1
+    range:
+      - 11
+      - 11
+    _id: Wld2eYAIAFr6VMWj
+    name: Glamour Stone
+    img: icons/commodities/gems/gem-cut-faceted-square-purple.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157057352
+      modifiedTime: 1754157331036
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.VQOlu2qzUmhX6rLH
+    _key: '!tables.results!YJQvjVgQD0LgytY3.Wld2eYAIAFr6VMWj'
+  - type: document
+    weight: 1
+    range:
+      - 12
+      - 12
+    _id: jTKBGveTOyKCfqis
+    name: Empty Chest
+    img: icons/containers/chest/chest-reinforced-steel-red.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157057536
+      modifiedTime: 1754157344171
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.AR7nSnENYGsBHbkE
+    _key: '!tables.results!YJQvjVgQD0LgytY3.jTKBGveTOyKCfqis'
+  - type: document
+    weight: 1
+    range:
+      - 13
+      - 13
+    _id: tMQgsCJ3znDCGDvs
+    name: Companion Case
+    img: icons/containers/chest/chest-simple-box-blue.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157057706
+      modifiedTime: 1754157357136
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.MvVqDUKpVEEYwIuC
+    _key: '!tables.results!YJQvjVgQD0LgytY3.tMQgsCJ3znDCGDvs'
+  - type: document
+    weight: 1
+    range:
+      - 14
+      - 14
+    _id: vSvnE6t28I9X1ZqN
+    name: Piercing Arrows
+    img: icons/skills/ranged/arrow-flying-spiral-blue.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157057895
+      modifiedTime: 1754157383811
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.DUiR3TxoUeQAY1LH
+    _key: '!tables.results!YJQvjVgQD0LgytY3.vSvnE6t28I9X1ZqN'
+  - type: document
+    weight: 1
+    range:
+      - 15
+      - 15
+    _id: NUeRWRkPh2usqzQJ
+    name: Valorstone
+    img: icons/commodities/currency/coin-engraved-tail-gold.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157059949
+      modifiedTime: 1754157398578
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.u1KFHud0GXXaln9L
+    _key: '!tables.results!YJQvjVgQD0LgytY3.NUeRWRkPh2usqzQJ'
+  - type: document
+    weight: 1
+    range:
+      - 16
+      - 16
+    _id: 4oaxwmQ245PQWvmT
+    name: Skeleton Key
+    img: icons/sundries/misc/key-steel.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157060129
+      modifiedTime: 1754157415855
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.Tdx2T1Gng0hMyPqJ
+    _key: '!tables.results!YJQvjVgQD0LgytY3.4oaxwmQ245PQWvmT'
+  - type: document
+    weight: 1
+    range:
+      - 17
+      - 17
+    _id: 7mhvyZUe01aZm6cq
+    name: Arcane Prism
+    img: icons/commodities/treasure/crown-blue-gold.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157060312
+      modifiedTime: 1754157426939
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.qPo77eUr5e0RKBHK
+    _key: '!tables.results!YJQvjVgQD0LgytY3.7mhvyZUe01aZm6cq'
+  - type: document
+    weight: 1
+    range:
+      - 18
+      - 18
+    _id: 0NHrlkBnZPMfJN4F
+    name: Minor Stamina Potion Recipe
+    img: icons/sundries/documents/document-letter-formal-tan.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157060499
+      modifiedTime: 1754157439006
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.NVNJhQCydsapzDIr
+    _key: '!tables.results!YJQvjVgQD0LgytY3.0NHrlkBnZPMfJN4F'
+  - type: document
+    weight: 1
+    range:
+      - 19
+      - 19
+    _id: KiHqL6EOgFFpdqej
+    name: Minor Health Potion Recipe
+    img: icons/sundries/documents/document-letter-blue.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157060675
+      modifiedTime: 1754157457589
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.GlpB9A02b6e2hFcG
+    _key: '!tables.results!YJQvjVgQD0LgytY3.KiHqL6EOgFFpdqej'
+  - type: document
+    weight: 1
+    range:
+      - 20
+      - 20
+    _id: spQazU2Bsyim1TvL
+    name: Homing Compasses
+    img: icons/tools/navigation/compass-worn-copper.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157060849
+      modifiedTime: 1754157472149
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.SSa62P1PZfCBZ7qf
+    _key: '!tables.results!YJQvjVgQD0LgytY3.spQazU2Bsyim1TvL'
+  - type: document
+    weight: 1
+    range:
+      - 21
+      - 21
+    _id: tkafCEdpED2cTd8Z
+    name: Corrector Sprite
+    img: icons/magic/control/mouth-smile-deception-purple.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157060984
+      modifiedTime: 1754157487061
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.AUswRFhYeZqLhGUq
+    _key: '!tables.results!YJQvjVgQD0LgytY3.tkafCEdpED2cTd8Z'
+  - type: document
+    weight: 1
+    range:
+      - 22
+      - 22
+    _id: 63I26yYYAvbOeSgO
+    name: Gecko Gloves
+    img: icons/equipment/hand/glove-ring-leather-green.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157062785
+      modifiedTime: 1754157496524
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.aOiRWDcZJZMZ2gRE
+    _key: '!tables.results!YJQvjVgQD0LgytY3.63I26yYYAvbOeSgO'
+  - type: document
+    weight: 1
+    range:
+      - 23
+      - 23
+    _id: IxmLqhvU7vcNVvit
+    name: Lorekeeper
+    img: icons/sundries/books/book-symbol-leaf-green.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157062960
+      modifiedTime: 1754157504697
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.lNTwsgNnk2SFsTK2
+    _key: '!tables.results!YJQvjVgQD0LgytY3.IxmLqhvU7vcNVvit'
+  - type: document
+    weight: 1
+    range:
+      - 24
+      - 24
+    _id: 5TiD860MuzpDdVDo
+    name: Vial of Darksmoke
+    img: icons/commodities/tech/smoke-bomb-purple.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157063137
+      modifiedTime: 1754157515116
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.q8Gk7KyaXcZiLn0Y
+    _key: '!tables.results!YJQvjVgQD0LgytY3.5TiD860MuzpDdVDo'
+  - type: document
+    weight: 1
+    range:
+      - 25
+      - 25
+    _id: PAwiNV8NVSMBzQxU
+    name: Bloodstone
+    img: icons/commodities/gems/gem-cluster-red.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157063281
+      modifiedTime: 1754157529193
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.9NM6sYtg1Fhxkoix
+    _key: '!tables.results!YJQvjVgQD0LgytY3.PAwiNV8NVSMBzQxU'
+  - type: document
+    weight: 1
+    range:
+      - 26
+      - 26
+    _id: 9aKB22jbDGIRiACp
+    name: Greatstone
+    img: icons/commodities/currency/coin-inset-copper-axe.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157064643
+      modifiedTime: 1754157544936
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.GBTQGVVZdKRk6Xrc
+    _key: '!tables.results!YJQvjVgQD0LgytY3.9aKB22jbDGIRiACp'
+  - type: document
+    weight: 1
+    range:
+      - 27
+      - 27
+    _id: oSVw59RSeEwxS2NM
+    name: Glider
+    img: icons/commodities/cloth/cloth-worn-blue.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157064798
+      modifiedTime: 1754157553857
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.biKjiYff6GjFasVc
+    _key: '!tables.results!YJQvjVgQD0LgytY3.oSVw59RSeEwxS2NM'
+  - type: document
+    weight: 1
+    range:
+      - 28
+      - 28
+    _id: GA81rYItHvdPkFoI
+    name: Ring of Silence
+    img: icons/equipment/finger/ring-cabochon-spiral-gold-green.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157064970
+      modifiedTime: 1754157563504
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.a6hyNvrufZ44TL8P
+    _key: '!tables.results!YJQvjVgQD0LgytY3.GA81rYItHvdPkFoI'
+  - type: document
+    weight: 1
+    range:
+      - 29
+      - 29
+    _id: hygjbPAmVDay5Qmd
+    name: Calming Pendant
+    img: icons/equipment/neck/amulet-round-blue.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157065126
+      modifiedTime: 1754157572872
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.L0rONpifcZLtuxif
+    _key: '!tables.results!YJQvjVgQD0LgytY3.hygjbPAmVDay5Qmd'
+  - type: document
+    weight: 1
+    range:
+      - 30
+      - 30
+    _id: v2sCOsMDWmcn6GCz
+    name: Dual Flask
+    img: icons/consumables/drinks/alcohol-spirits-bottle-green.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157065283
+      modifiedTime: 1754157581269
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.Wwvt4q4eDmOGYx6c
+    _key: '!tables.results!YJQvjVgQD0LgytY3.v2sCOsMDWmcn6GCz'
+  - type: document
+    weight: 1
+    range:
+      - 31
+      - 31
+    _id: FWyU9z3hpJfRq0dV
+    name: Bag of Ficklesand
+    img: icons/containers/bags/sack-worn-brown.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157066975
+      modifiedTime: 1754157589885
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.iiXcPXN8RCWn8Mrf
+    _key: '!tables.results!YJQvjVgQD0LgytY3.FWyU9z3hpJfRq0dV'
+  - type: document
+    weight: 1
+    range:
+      - 32
+      - 32
+    _id: zkX5u1jUIDmzKfti
+    name: Ring of Resistance
+    img: icons/equipment/finger/ring-shield-silver.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157067158
+      modifiedTime: 1754157599610
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.nJGPONYBlhhsAqOZ
+    _key: '!tables.results!YJQvjVgQD0LgytY3.zkX5u1jUIDmzKfti'
+  - type: document
+    weight: 1
+    range:
+      - 33
+      - 33
+    _id: FKf71VQyWZCad81o
+    name: Phoenix Feather
+    img: icons/commodities/materials/feather-orange.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157067314
+      modifiedTime: 1754157610043
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.vvwygAds3ccHNBqI
+    _key: '!tables.results!YJQvjVgQD0LgytY3.FKf71VQyWZCad81o'
+  - type: document
+    weight: 1
+    range:
+      - 34
+      - 34
+    _id: 19jmkVNSkZWRO85A
+    name: Box of Many Goods
+    img: icons/containers/chest/chest-reinforced-box-brown.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157067484
+      modifiedTime: 1754157619250
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.LBebTBJk8CAg22ET
+    _key: '!tables.results!YJQvjVgQD0LgytY3.19jmkVNSkZWRO85A'
+  - type: document
+    weight: 1
+    range:
+      - 35
+      - 35
+    _id: XQgfmPnDw1uylRqz
+    name: Airblade Charm
+    img: icons/commodities/treasure/token-engraved-spiral-grey.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157067656
+      modifiedTime: 1754157627544
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.pI7OxC8aORVEB93w
+    _key: '!tables.results!YJQvjVgQD0LgytY3.XQgfmPnDw1uylRqz'
+  - type: document
+    weight: 1
+    range:
+      - 36
+      - 36
+    _id: mJzlc69pU7tTWiA7
+    name: Portal Seed
+    img: icons/commodities/materials/plant-sprout-teal.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157067814
+      modifiedTime: 1754157635514
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.XQDJECHAp0qcGvgc
+    _key: '!tables.results!YJQvjVgQD0LgytY3.mJzlc69pU7tTWiA7'
+  - type: document
+    weight: 1
+    range:
+      - 37
+      - 37
+    _id: pLDMdN7qYg2Eyxis
+    name: Paragon’s Chain
+    img: icons/equipment/neck/amulet-round-engraved-blue.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157067986
+      modifiedTime: 1754157644015
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.Epi7TkQohxsIamGl
+    _key: '!tables.results!YJQvjVgQD0LgytY3.pLDMdN7qYg2Eyxis'
+  - type: document
+    weight: 1
+    range:
+      - 38
+      - 38
+    _id: WTyvcW8JCkVWbZLf
+    name: Elusive Amulet
+    img: icons/equipment/neck/necklace-triquetra-silver.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157069534
+      modifiedTime: 1754157652435
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.YwtxMakAe7576wsh
+    _key: '!tables.results!YJQvjVgQD0LgytY3.WTyvcW8JCkVWbZLf'
+  - type: document
+    weight: 1
+    range:
+      - 39
+      - 39
+    _id: 2GHU1o3wJyu4fBFs
+    name: Hopekeeper Locket
+    img: icons/equipment/neck/amulet-round-engraved-spiral-gold.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157069702
+      modifiedTime: 1754157660632
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.hXl3zZyGK2YSsjgg
+    _key: '!tables.results!YJQvjVgQD0LgytY3.2GHU1o3wJyu4fBFs'
+  - type: document
+    weight: 1
+    range:
+      - 40
+      - 40
+    _id: E9sr9XV18ruQiNKY
+    name: Infinite Bag
+    img: icons/containers/bags/pack-leather-black-brown.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157069875
+      modifiedTime: 1754157673257
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.AP1Dia1WFioQgqQn
+    _key: '!tables.results!YJQvjVgQD0LgytY3.E9sr9XV18ruQiNKY'
+  - type: document
+    weight: 1
+    range:
+      - 41
+      - 41
+    _id: Tb81bC4yL2LeiggO
+    name: Stride Relic
+    img: icons/commodities/treasure/plaque-wood-leaves.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157070035
+      modifiedTime: 1754157683763
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.4rTtsXQ6eOjZFNb3
+    _key: '!tables.results!YJQvjVgQD0LgytY3.Tb81bC4yL2LeiggO'
+  - type: document
+    weight: 1
+    range:
+      - 42
+      - 42
+    _id: BCIYr5xq7pGQeDOv
+    name: Bolster Relic
+    img: icons/commodities/treasure/brooch-crown-gold.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157070183
+      modifiedTime: 1754157693450
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.51iseriohcT6EH8M
+    _key: '!tables.results!YJQvjVgQD0LgytY3.BCIYr5xq7pGQeDOv'
+  - type: document
+    weight: 1
+    range:
+      - 43
+      - 43
+    _id: 9AdYrnACMBMOxwUY
+    name: Control Relic
+    img: icons/commodities/treasure/token-worn-yang-brown.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157071672
+      modifiedTime: 1754157989039
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.MZmHHEXMCSQBncUR
+    _key: '!tables.results!YJQvjVgQD0LgytY3.9AdYrnACMBMOxwUY'
+  - type: document
+    weight: 1
+    range:
+      - 44
+      - 44
+    _id: IKd9RzPkj5FNm9BD
+    name: Attune Relic
+    img: icons/commodities/treasure/token-runed-spiral-grey.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157071839
+      modifiedTime: 1754157751139
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.lyXRyKQ914WrnMdp
+    _key: '!tables.results!YJQvjVgQD0LgytY3.IKd9RzPkj5FNm9BD'
+  - type: document
+    weight: 1
+    range:
+      - 45
+      - 45
+    _id: A2Qztaav2pLrMmkr
+    name: Charm Relic
+    img: icons/commodities/treasure/token-runed-circles-purple.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157072015
+      modifiedTime: 1754157761299
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.PwT2D4Q7kmd6wCdI
+    _key: '!tables.results!YJQvjVgQD0LgytY3.A2Qztaav2pLrMmkr'
+  - type: document
+    weight: 1
+    range:
+      - 46
+      - 46
+    _id: Gx646RqEBN3HGuyZ
+    name: Enlighten Relic
+    img: icons/commodities/treasure/brooch-eye-silver-teal.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157072188
+      modifiedTime: 1754157769393
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.gkmWJMR9obH2ZgAM
+    _key: '!tables.results!YJQvjVgQD0LgytY3.Gx646RqEBN3HGuyZ'
+  - type: document
+    weight: 1
+    range:
+      - 47
+      - 47
+    _id: 3HM9cUkmWwEGp8eJ
+    name: Honing Relic
+    img: icons/commodities/treasure/token-silver-gem-cut.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157073486
+      modifiedTime: 1754157781787
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.Aez7qnAuNMM3aWZ3
+    _key: '!tables.results!YJQvjVgQD0LgytY3.3HM9cUkmWwEGp8eJ'
+  - type: document
+    weight: 1
+    range:
+      - 48
+      - 48
+    _id: 6zDWaNUYVffEew29
+    name: Flickerfly Pendant
+    img: icons/commodities/gems/gem-amber-insect-orange.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157073652
+      modifiedTime: 1754157794109
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.bk4FhnV9RkWjc8Rp
+    _key: '!tables.results!YJQvjVgQD0LgytY3.6zDWaNUYVffEew29'
+  - type: document
+    weight: 1
+    range:
+      - 49
+      - 49
+    _id: mXBLnCo0hG3WNOAf
+    name: Lakestrider Boots
+    img: icons/equipment/feet/shoes-collared-leather-blue.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157073820
+      modifiedTime: 1754157803893
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.XY5fpMYMOd2noyIy
+    _key: '!tables.results!YJQvjVgQD0LgytY3.mXBLnCo0hG3WNOAf'
+  - type: document
+    weight: 1
+    range:
+      - 50
+      - 50
+    _id: cRrjOERYfj3Zm54H
+    name: Clay Companion
+    img: icons/commodities/treasure/figurine-rabbit.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157073994
+      modifiedTime: 1754157813556
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.bsQ473VeMLoUoQ8i
+    _key: '!tables.results!YJQvjVgQD0LgytY3.cRrjOERYfj3Zm54H'
+  - type: document
+    weight: 1
+    range:
+      - 51
+      - 51
+    _id: fbkt2xB5pESxEJEr
+    name: Mythic Dust Recipe
+    img: icons/sundries/documents/document-bound-white-tan.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157074152
+      modifiedTime: 1754157826523
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.v4lgb1wPDO7qHPcO
+    _key: '!tables.results!YJQvjVgQD0LgytY3.fbkt2xB5pESxEJEr'
+  - type: document
+    weight: 1
+    range:
+      - 52
+      - 52
+    _id: C3XFdbTpkY5t32L7
+    name: Shard of Memory
+    img: icons/commodities/gems/pearl-swirl-blue.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157074307
+      modifiedTime: 1754157837452
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.NjTdg1p5Dnu0aP48
+    _key: '!tables.results!YJQvjVgQD0LgytY3.C3XFdbTpkY5t32L7'
+  - type: document
+    weight: 1
+    range:
+      - 53
+      - 53
+    _id: KvHlsgyQrLWqHWKY
+    name: Gem of Alacrity
+    img: icons/commodities/gems/gem-faceted-diamond-green.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157076047
+      modifiedTime: 1754157847669
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.9BoiPDVVr0IVF0g5
+    _key: '!tables.results!YJQvjVgQD0LgytY3.KvHlsgyQrLWqHWKY'
+  - type: document
+    weight: 1
+    range:
+      - 54
+      - 54
+    _id: 2IavjD7DRU5gl1a3
+    name: Gem of Might
+    img: icons/commodities/gems/gem-rough-cushion-orange-white.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157076378
+      modifiedTime: 1754157855384
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.OYw11ikWeswAEjNi
+    _key: '!tables.results!YJQvjVgQD0LgytY3.2IavjD7DRU5gl1a3'
+  - type: document
+    weight: 1
+    range:
+      - 55
+      - 55
+    _id: hYTE98dBcvTcK1tE
+    name: Gem of Precision
+    img: icons/commodities/gems/gem-raw-rough-purple.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157076536
+      modifiedTime: 1754157862986
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.hMLTV9GIHfCyLcqi
+    _key: '!tables.results!YJQvjVgQD0LgytY3.hYTE98dBcvTcK1tE'
+  - type: document
+    weight: 1
+    range:
+      - 56
+      - 56
+    _id: uDvEy5XtJG9yy52m
+    name: Gem of Insight
+    img: icons/commodities/gems/gem-faceted-round-white.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157078161
+      modifiedTime: 1754157870102
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.9KCydrNOT6lOLEHn
+    _key: '!tables.results!YJQvjVgQD0LgytY3.uDvEy5XtJG9yy52m'
+  - type: document
+    weight: 1
+    range:
+      - 57
+      - 57
+    _id: evGGgyTMoJ4Z4Ust
+    name: Gem of Audacity
+    img: icons/commodities/gems/gem-faceted-diamond-pink-gold.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157078348
+      modifiedTime: 1754157877935
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.ws8V4QQDIhLG52mT
+    _key: '!tables.results!YJQvjVgQD0LgytY3.evGGgyTMoJ4Z4Ust'
+  - type: document
+    weight: 1
+    range:
+      - 58
+      - 58
+    _id: 7FwfQyrlLuvS4QoO
+    name: Gem of Sagacity
+    img: icons/commodities/gems/gem-faceted-teardrop-blue.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157078520
+      modifiedTime: 1754157885458
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.zfexTiBmTjpmUxZv
+    _key: '!tables.results!YJQvjVgQD0LgytY3.7FwfQyrlLuvS4QoO'
+  - type: document
+    weight: 1
+    range:
+      - 59
+      - 59
+    _id: ebAN808duy7zDrEK
+    name: Ring of Unbreakable Resolve
+    img: icons/equipment/finger/ring-faceted-engraved-gold-purple.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157079903
+      modifiedTime: 1754157896093
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.lje9OcZ2huhlTaxA
+    _key: '!tables.results!YJQvjVgQD0LgytY3.ebAN808duy7zDrEK'
+  - type: document
+    weight: 1
+    range:
+      - 60
+      - 60
+    _id: SHcbYetMDwi0yB9w
+    name: Belt of Unity
+    img: icons/equipment/waist/belt-buckle-spiral-blue.webp
+    description: ''
+    drawn: false
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.346'
+      systemId: daggerheart
+      systemVersion: 2.11.5
+      createdTime: 1754157082774
+      modifiedTime: 1754157906772
+      lastModifiedBy: PBdPE9squMuZKhHK
+    documentUuid: Compendium.daggerheart-srd.srd-items.Item.FAcDxmaIzZOPYqAd
+    _key: '!tables.results!YJQvjVgQD0LgytY3.SHcbYetMDwi0yB9w'
+replacement: true
+displayRoll: true
+folder: null
+sort: 0
+ownership:
+  default: 0
+  PBdPE9squMuZKhHK: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.346'
+  systemId: daggerheart
+  systemVersion: 2.11.5
+  createdTime: 1754156993991
+  modifiedTime: 1754157260262
+  lastModifiedBy: PBdPE9squMuZKhHK
+formula: 1d61
+_key: '!tables!YJQvjVgQD0LgytY3'

--- a/data/srd-tables/Loot_YJQvjVgQD0LgytY3.yml
+++ b/data/srd-tables/Loot_YJQvjVgQD0LgytY3.yml
@@ -1384,7 +1384,7 @@ results:
     documentUuid: Compendium.daggerheart-srd.srd-items.Item.FAcDxmaIzZOPYqAd
     _key: '!tables.results!YJQvjVgQD0LgytY3.SHcbYetMDwi0yB9w'
 replacement: true
-displayRoll: true
+displayRoll: false
 folder: null
 sort: 0
 ownership:
@@ -1399,7 +1399,7 @@ _stats:
   systemId: daggerheart
   systemVersion: 2.11.5
   createdTime: 1754156993991
-  modifiedTime: 1754157260262
+  modifiedTime: 1754159734455
   lastModifiedBy: PBdPE9squMuZKhHK
-formula: 1d61
+formula: 1d60
 _key: '!tables!YJQvjVgQD0LgytY3'

--- a/module.json
+++ b/module.json
@@ -70,10 +70,23 @@
         "PLAYER": "OBSERVER",
         "ASSISTANT": "OWNER"
       }
+    },
+    {
+      "name": "srd-tables",
+      "label": "srd-tables",
+      "path": "packs/srd-tables",
+      "type": "RollTable",
+      "ownership": {
+        "PLAYER": "OBSERVER",
+        "ASSISTANT": "OWNER"
+      },
+      "system": "daggerheart"
     }
   ],
   "url": "https://github.com/unofficial-daggerheart/daggerheart-srd",
   "bugs": "https://github.com/unofficial-daggerheart/daggerheart-srd/issues",
   "download": "https://github.com/unofficial-daggerheart/daggerheart-srd/releases/latest/download/module.zip",
-  "manifest": "https://github.com/unofficial-daggerheart/daggerheart-srd/releases/latest/download/module.json"
+  "manifest": "https://github.com/unofficial-daggerheart/daggerheart-srd/releases/latest/download/module.json",
+  "description": "",
+  "flags": {}
 }


### PR DESCRIPTION
Branched from #22 

- Added new Compendium called "Tables"
- Added "Loot" table containing all loot items (item order copied from SRD)
- Added "Consumable" table containing all consumable items (item order copied from SRD)
- Added missing "Control Potion" item
- Replaced Gill Salve image as it was used elsewhere

<img width="1815" height="1294" alt="image" src="https://github.com/user-attachments/assets/1c383543-daa8-4823-8268-7c81f214c9df" />
